### PR TITLE
Feat/MyProfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "classnames": "^2.3.1",
         "react": "^18.1.0",
+        "react-circular-progressbar": "^2.0.4",
         "react-dom": "^18.1.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
@@ -13896,6 +13897,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-circular-progressbar": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.4.tgz",
+      "integrity": "sha512-OfX0ThSxRYEVGaQSt0DlXfyl5w4DbXHsXetyeivmoQrh9xA9bzVPHNf8aAhOIiwiaxX2WYWpLDB3gcpsDJ9oww==",
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -27164,6 +27173,12 @@
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
       }
+    },
+    "react-circular-progressbar": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.4.tgz",
+      "integrity": "sha512-OfX0ThSxRYEVGaQSt0DlXfyl5w4DbXHsXetyeivmoQrh9xA9bzVPHNf8aAhOIiwiaxX2WYWpLDB3gcpsDJ9oww==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "classnames": "^2.3.1",
     "react": "^18.1.0",
+    "react-circular-progressbar": "^2.0.4",
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/src/components/MenuProfile/ArrowSvg.js
+++ b/src/components/MenuProfile/ArrowSvg.js
@@ -1,0 +1,22 @@
+function ArrowSvg() {
+  return (
+    <svg
+      enableBackground='new 0 0 15 26'
+      height='26px'
+      id='Layer_1'
+      version='1.1'
+      viewBox='0 0 15 26'
+      width='15px'
+      xmlSpace='preserve'
+      xmlns='http://www.w3.org/2000/svg'
+      xmlnsXlink='http://www.w3.org/1999/xlink'
+    >
+      <polygon
+        fill='#231F20'
+        points='12.885,0.58 14.969,2.664 4.133,13.5 14.969,24.336 12.885,26.42 2.049,15.584 -0.035,13.5 '
+      />
+    </svg>
+  )
+}
+
+export default ArrowSvg

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import styles from './MenuProfile.module.scss'
 
 import { CircularProgressbar } from 'react-circular-progressbar'
@@ -5,12 +6,18 @@ import CIRCLE_STYLE from './progressBarStyle'
 import ArrowSvg from './ArrowSvg'
 
 // eslint-disable-next-line react/prop-types
-function MenuProfile({ name, picSrc }) {
+function MenuProfile({ name, picSrc, todoMax, todoCount }) {
+  const [percentage, setPercentage] = useState(0)
+
+  useEffect(() => {
+    setPercentage((todoCount * 100) / todoMax)
+  }, [todoMax, todoCount])
+
   return (
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
         <div className={styles.imageDiv}>
-          <CircularProgressbar value={30} className={styles.progressBar} styles={CIRCLE_STYLE} />
+          <CircularProgressbar value={percentage} className={styles.progressBar} styles={CIRCLE_STYLE} />
           <img src={picSrc} alt='profilePic' />
         </div>
         <h1>{name}</h1>

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -1,39 +1,17 @@
 import styles from './MenuProfile.module.scss'
 
-import { CircularProgressbarWithChildren } from 'react-circular-progressbar'
-
-const CIRCLE_STYLE = {
-  root: {},
-  path: {
-    stroke: 'rgba(62, 152, 199, 100%)',
-    strokeLinecap: 'butt',
-    transition: 'stroke-dashoffset 0.5s ease 0s',
-    transform: 'rotate(0.25turn)',
-    transformOrigin: 'center center',
-  },
-  trail: {
-    stroke: '#d6d6d6',
-    strokeLinecap: 'butt',
-    transform: 'rotate(0.25turn)',
-    transformOrigin: 'center center',
-  },
-  text: {
-    fill: '#f88',
-    fontSize: '16px',
-  },
-  background: {
-    fill: '#3e98c7',
-  },
-}
+import { CircularProgressbar } from 'react-circular-progressbar'
+import CIRCLE_STYLE from './progressBarStyle'
 
 // eslint-disable-next-line react/prop-types
 function MenuProfile({ name, picSrc }) {
   return (
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
-        <CircularProgressbarWithChildren value={66} className={styles.progressBar} styles={CIRCLE_STYLE}>
+        <div className={styles.imageDiv}>
+          <CircularProgressbar value={30} className={styles.progressBar} styles={CIRCLE_STYLE} />
           <img src={picSrc} alt='profilePic' />
-        </CircularProgressbarWithChildren>
+        </div>
         <h1>{name}</h1>
       </div>
       <button type='button' className={styles.buttonWrapper}>

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -13,6 +13,11 @@ function MenuProfile({ name, picSrc, todoMax, todoCount }) {
     setPercentage((todoCount * 100) / todoMax)
   }, [todoMax, todoCount])
 
+  const handleBtnClick = () => {
+    console.log('clicked')
+    // 버튼 클릭 시 메뉴창 닫는 이벤트 추가
+  }
+
   return (
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
@@ -22,7 +27,7 @@ function MenuProfile({ name, picSrc, todoMax, todoCount }) {
         </div>
         <h1>{name}</h1>
       </div>
-      <button type='button' className={styles.buttonWrapper}>
+      <button type='button' className={styles.buttonWrapper} onClick={handleBtnClick}>
         <ArrowSvg />
       </button>
     </div>

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -1,0 +1,15 @@
+import styles from './MenuProfile.module.scss'
+
+function MenuProfile() {
+  return (
+    <div className={styles.profileDiv}>
+      <div className={styles.profileSect}>
+        <img src='logo192.png' alt='profilePic' />
+        <h1 className='nickname'>TestNickname</h1>
+      </div>
+      <button type='button'>{'<'}</button>
+    </div>
+  )
+}
+
+export default MenuProfile

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -2,6 +2,7 @@ import styles from './MenuProfile.module.scss'
 
 import { CircularProgressbar } from 'react-circular-progressbar'
 import CIRCLE_STYLE from './progressBarStyle'
+import ArrowSvg from './ArrowSvg'
 
 // eslint-disable-next-line react/prop-types
 function MenuProfile({ name, picSrc }) {
@@ -15,7 +16,7 @@ function MenuProfile({ name, picSrc }) {
         <h1>{name}</h1>
       </div>
       <button type='button' className={styles.buttonWrapper}>
-        {'<'}
+        <ArrowSvg />
       </button>
     </div>
   )

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -1,17 +1,22 @@
 import styles from './MenuProfile.module.scss'
 
-function MenuProfile() {
+function MenuProfile({ name, picSrc }) {
   return (
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
-        <img src='logo192.png' alt='profilePic' />
-        <h1>Joy Mitchell</h1>
+        <img src={picSrc} alt='profilePic' />
+        <h1>{name}</h1>
       </div>
       <button type='button' className={styles.buttonWrapper}>
         {'<'}
       </button>
     </div>
   )
+}
+
+MenuProfile.propTypes = {
+  name: String,
+  picSrc: String,
 }
 
 export default MenuProfile

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -5,9 +5,11 @@ function MenuProfile() {
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
         <img src='logo192.png' alt='profilePic' />
-        <h1 className='nickname'>TestNickname</h1>
+        <h1>Joy Mitchell</h1>
       </div>
-      <button type='button'>{'<'}</button>
+      <button type='button' className={styles.buttonWrapper}>
+        {'<'}
+      </button>
     </div>
   )
 }

--- a/src/components/MenuProfile/MenuProfile.js
+++ b/src/components/MenuProfile/MenuProfile.js
@@ -1,10 +1,39 @@
 import styles from './MenuProfile.module.scss'
 
+import { CircularProgressbarWithChildren } from 'react-circular-progressbar'
+
+const CIRCLE_STYLE = {
+  root: {},
+  path: {
+    stroke: 'rgba(62, 152, 199, 100%)',
+    strokeLinecap: 'butt',
+    transition: 'stroke-dashoffset 0.5s ease 0s',
+    transform: 'rotate(0.25turn)',
+    transformOrigin: 'center center',
+  },
+  trail: {
+    stroke: '#d6d6d6',
+    strokeLinecap: 'butt',
+    transform: 'rotate(0.25turn)',
+    transformOrigin: 'center center',
+  },
+  text: {
+    fill: '#f88',
+    fontSize: '16px',
+  },
+  background: {
+    fill: '#3e98c7',
+  },
+}
+
+// eslint-disable-next-line react/prop-types
 function MenuProfile({ name, picSrc }) {
   return (
     <div className={styles.profileDiv}>
       <div className={styles.profileSect}>
-        <img src={picSrc} alt='profilePic' />
+        <CircularProgressbarWithChildren value={66} className={styles.progressBar} styles={CIRCLE_STYLE}>
+          <img src={picSrc} alt='profilePic' />
+        </CircularProgressbarWithChildren>
         <h1>{name}</h1>
       </div>
       <button type='button' className={styles.buttonWrapper}>
@@ -12,11 +41,6 @@ function MenuProfile({ name, picSrc }) {
       </button>
     </div>
   )
-}
-
-MenuProfile.propTypes = {
-  name: String,
-  picSrc: String,
 }
 
 export default MenuProfile

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -27,7 +27,7 @@
   img {
     position: absolute;
     width: 3.7rem;
-    background-color: #ffffff;
+    background-color: colors.$WHITE;
     border-radius: 50%;
   }
 
@@ -48,7 +48,7 @@
   width: 2.3rem;
   height: 2.3rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 100%);
+  color: colors.$WHITE;
   border: 1.5px solid rgba(255, 255, 255, 30%);
   border-radius: 50%;
 
@@ -57,6 +57,6 @@
   }
 
   polygon {
-    fill: rgba(255, 255, 255, 100%);
+    fill: colors.$WHITE;
   }
 }

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -1,27 +1,41 @@
+@use '/src/styles/constants/colors';
+
 .profileDiv {
   display: flex;
   flex-direction: row;
+  padding: 2rem 1rem;
 }
 
 .profileSect {
   display: flex;
   flex-direction: column;
-  width: 100rem;
-  background-color: aqua;
+  align-items: left;
+  justify-content: center;
+  width: 50%;
+  padding: 1rem;
 
   & > img {
-    width: 30%;
+    width: 4rem;
+    margin-bottom: 2rem;
     background-color: #ffffff;
     border-radius: 50%;
   }
 
-  .nickname {
-    font-size: 10rem;
-    font-weight: 700;
+  h1 {
+    width: 100%;
+    font-size: 1.7rem;
+    font-weight: 600;
+    line-height: 2rem;
+    color: colors.$WHITE;
+    letter-spacing: 0.1px;
   }
 }
 
 .buttonWrapper {
-  color: #ffffff;
-  background-color: teal;
+  width: 2.3rem;
+  height: 2.3rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 100%);
+  border: 1px solid rgba(255, 255, 255, 50%);
+  border-radius: 50%;
 }

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -21,6 +21,7 @@
     justify-content: center;
     width: 5rem;
     height: 5rem;
+    margin-bottom: 1rem;
   }
 
   img {
@@ -41,10 +42,21 @@
 }
 
 .buttonWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 2.3rem;
   height: 2.3rem;
   font-weight: 700;
   color: rgba(255, 255, 255, 100%);
   border: 1px solid rgba(255, 255, 255, 50%);
   border-radius: 50%;
+
+  svg {
+    width: 0.5rem;
+  }
+
+  polygon {
+    fill: rgba(255, 255, 255, 100%);
+  }
 }

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -1,0 +1,27 @@
+.profileDiv {
+  display: flex;
+  flex-direction: row;
+}
+
+.profileSect {
+  display: flex;
+  flex-direction: column;
+  width: 100rem;
+  background-color: aqua;
+
+  & > img {
+    width: 30%;
+    background-color: #ffffff;
+    border-radius: 50%;
+  }
+
+  .nickname {
+    font-size: 10rem;
+    font-weight: 700;
+  }
+}
+
+.buttonWrapper {
+  color: #ffffff;
+  background-color: teal;
+}

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -49,7 +49,7 @@
   height: 2.3rem;
   font-weight: 700;
   color: rgba(255, 255, 255, 100%);
-  border: 1px solid rgba(255, 255, 255, 50%);
+  border: 1.5px solid rgba(255, 255, 255, 30%);
   border-radius: 50%;
 
   svg {

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -14,9 +14,18 @@
   width: 50%;
   padding: 1rem;
 
+  .imageDiv {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 5rem;
+    height: 5rem;
+  }
+
   img {
-    width: 4rem;
-    margin-bottom: 2rem;
+    position: absolute;
+    width: 3.7rem;
     background-color: #ffffff;
     border-radius: 50%;
   }

--- a/src/components/MenuProfile/MenuProfile.module.scss
+++ b/src/components/MenuProfile/MenuProfile.module.scss
@@ -14,7 +14,7 @@
   width: 50%;
   padding: 1rem;
 
-  & > img {
+  img {
     width: 4rem;
     margin-bottom: 2rem;
     background-color: #ffffff;

--- a/src/components/MenuProfile/progressBarStyle.js
+++ b/src/components/MenuProfile/progressBarStyle.js
@@ -1,0 +1,24 @@
+const CIRCLE_STYLE = {
+  root: {},
+  path: {
+    stroke: '#E402F7',
+    strokeWidth: '3px',
+    transition: 'stroke-dashoffset 0.5s ease 0s',
+    transformOrigin: 'center center',
+  },
+  trail: {
+    stroke: '#405586',
+    strokeWidth: '3px',
+    strokeLinecap: 'butt',
+    transformOrigin: 'center center',
+  },
+  text: {
+    fill: '#f88',
+    fontSize: '16px',
+  },
+  background: {
+    fill: '#ffffff',
+  },
+}
+
+export default CIRCLE_STYLE


### PR DESCRIPTION
![May-05-2022 18-00-14](https://user-images.githubusercontent.com/37893979/166892758-be7a0d7a-ec71-46ba-95cd-84d9b1e7dbb7.gif)

### 프로그레스바 (프로필 사진 주변 원)
- 컴포넌트 리렌더링 시 (메뉴 열고 해당 컴포넌트 렌더링 될 때) 프로필사진 주변의 프로그레스바에 애니메이션이 들어갑니다
- 투두 리스트의 총 개수와 완료한 투두 개수를 받아오며, 이를 이용하여 완료한 투두 비율을 계산하고 프로그레스바에 적용합니다
- 프로그레스바는 [react-circular-progressbar](https://www.npmjs.com/package/react-circular-progressbar) 사용하였습니다

### props 관련 설명
- 이미지 src 링크와 닉네임은 props로 받아옵니다
- 프로필 사진 고화질이 없어서 일단 아무 사진이나 올려 테스트했습니다

### 핸들러
- 뒤로가기 버튼 클릭 시 동작하는 핸들러 내부는 일단 console.log로 동작 테스트만 해봤고, 여기에 메뉴 닫는 동작 연결하면 됩니다

### 해야할 것
- 메뉴 컴포넌트 전부 합치고 미세한 margin이나 padding 조정